### PR TITLE
change `countna` to return number of missing values

### DIFF
--- a/R/missingValues.R
+++ b/R/missingValues.R
@@ -9,7 +9,7 @@ NULL
 missingValues <- function(QCreportObject) {
 
   countna <- function(x)
-    return((sum(is.na(x)) / length(x)) * 100L)
+    return(sum(is.na(x))
 
   # Remove QC lead samples from peakMatrix
   rem_hits <- which(QCreportObject$metaData$samp_lab=="Removed")
@@ -23,8 +23,8 @@ missingValues <- function(QCreportObject) {
     samp_lab <- QCreportObject$metaData$samp_lab
   }
 
-  across_samples <- data.frame(x=apply(peak_matrix, 2L, countna))
-  across_features <- data.frame(x=apply(peak_matrix, 1L, countna))
+  across_samples <- data.frame(x=apply(peak_matrix, 2L, countna))/nrow(peak_matrix)*100
+  across_features <- data.frame(x=apply(peak_matrix, 1L, countna))/ncol(peak_matrix)*100
 
   QCreportObject$plots$MVplot1 <- ggplot(data=across_samples, aes_(~x)) +
     geom_histogram() +


### PR DESCRIPTION
Fix for https://github.com/computational-metabolomics/qcrms/issues/11
`out_across_features` is correctly calculating percent missing but only if `countna` returns the number missing and not percentage missing.

- Changed `countna` to return the number of missing values instead of the percent missing
- Updated `across_samples` and `across_features` to reflect this change
- `out_across_features` was already calculating percent missing so wasn't changed